### PR TITLE
Add options for specifying template repository and repository name 

### DIFF
--- a/gh-mini-arc
+++ b/gh-mini-arc
@@ -17,10 +17,10 @@ while getopts ":s:t:n:h" opt; do
             fi
             ;;
         t)
-            TEMPLATE_REPO=$OPTARG
+            TEMPLATE_REPO="$(echo $OPTARG | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-' | cut -c 1-100)"
             ;;
         n)
-            REPO_NAME=$OPTARG
+            REPO_NAME="$(echo $OPTARG | tr '[:upper:]' '[:lower:]' | tr ' ' '-' | tr -cd '[:alnum:]-' | cut -c 1-100)"
             ;;
         h)
             echo "Usage: $0 [options]"
@@ -45,12 +45,12 @@ if [ -z "${scalesets}" ]; then
   scalesets="arc-runner-set"
 fi
 
-gh repo create ${REPO_NAME} --private --template ${TEMPLATE_REPO} --clone
+gh repo create "${REPO_NAME}" --private --template ${TEMPLATE_REPO} --clone
 if [ $? -ne 0 ]; then
   exit 1
 fi
 
-cd ${REPO_NAME}
+cd "${REPO_NAME}"
 
 gh secret set FAST_ARC_TOKEN -a codespaces --repo ${REPO_OWNER}/${REPO_NAME} --body "$(gh auth token)"
 if [ $? -ne 0 ]; then

--- a/gh-mini-arc
+++ b/gh-mini-arc
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 set -e
 
-REPO_NAME="fast-arc-$(date +%s)"
 REPO_OWNER="$(gh api user --jq '.login')"
 template_repo="BagToad/mini-arc-template"
+REPO_NAME="fast-arc-$(date +%s)"
 
-while getopts ":s:t:h-:" opt; do
+while getopts ":s:t:n:h-:" opt; do
   case ${opt} in
     s)
       grep -E '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$' <<< "${OPTARG}"  > /dev/null 2>&1 || { echo "Invalid scaleset name: ${OPTARG}"; exit 1; }
@@ -19,12 +19,16 @@ while getopts ":s:t:h-:" opt; do
       # echo "scalesets: ${scalesets}"
       ;;
     t)
-      template_rep=$OPTARG
+      template_repo=$OPTARG
+      ;;
+    n)
+      REPO_NAME=$OPTARG
       ;;
     h)
       echo "Usage: $0 [options]"
       echo "  -s, --scalesets <scalesets>  The scalesets to create secrets for"
       echo "  -t, --template <template>  The template repo to use"
+      echo "  -n, --name <name>  The name for the new repository"
       exit 0
       ;;
     -)

--- a/gh-mini-arc
+++ b/gh-mini-arc
@@ -15,8 +15,6 @@ while getopts ":s:t:n:h" opt; do
             else 
                 scalesets="${scalesets}:${OPTARG}"
             fi
-
-            # echo "scalesets: ${scalesets}"
             ;;
         t)
             TEMPLATE_REPO=$OPTARG

--- a/gh-mini-arc
+++ b/gh-mini-arc
@@ -2,7 +2,7 @@
 set -e
 
 REPO_OWNER="$(gh api user --jq '.login')"
-template_repo="BagToad/mini-arc-template"
+TEMPLATE_REPO="BagToad/mini-arc-template"
 REPO_NAME="fast-arc-$(date +%s)"
 
 while getopts ":s:t:n:h" opt; do
@@ -19,7 +19,7 @@ while getopts ":s:t:n:h" opt; do
             # echo "scalesets: ${scalesets}"
             ;;
         t)
-            template_repo=$OPTARG
+            TEMPLATE_REPO=$OPTARG
             ;;
         n)
             REPO_NAME=$OPTARG
@@ -47,7 +47,7 @@ if [ -z "${scalesets}" ]; then
   scalesets="arc-runner-set"
 fi
 
-gh repo create ${REPO_NAME} --private --template ${template_repo} --clone
+gh repo create ${REPO_NAME} --private --template ${TEMPLATE_REPO} --clone
 if [ $? -ne 0 ]; then
   exit 1
 fi

--- a/gh-mini-arc
+++ b/gh-mini-arc
@@ -26,7 +26,7 @@ while getopts ":s:t:n:h-:" opt; do
       ;;
     h)
       echo "Usage: $0 [options]"
-      echo "  -s, --scalesets <scalesets>  The scalesets to create secrets for"
+      echo "  -s, --scaleset <scaleset>  The scalesets to create secrets for"
       echo "  -t, --template <template>  The template repo to use"
       echo "  -n, --name <name>  The name for the new repository"
       exit 0

--- a/gh-mini-arc
+++ b/gh-mini-arc
@@ -5,51 +5,41 @@ REPO_OWNER="$(gh api user --jq '.login')"
 template_repo="BagToad/mini-arc-template"
 REPO_NAME="fast-arc-$(date +%s)"
 
-while getopts ":s:t:n:h-:" opt; do
-  case ${opt} in
-    s)
-      grep -E '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$' <<< "${OPTARG}"  > /dev/null 2>&1 || { echo "Invalid scaleset name: ${OPTARG}"; exit 1; }
-      
-      if [ -z "${scalesets}" ]; then
-        scalesets="${OPTARG}"
-      else 
-        scalesets="${scalesets}:${OPTARG}"
-      fi
+while getopts ":s:t:n:h" opt; do
+    case ${opt} in
+        s)
+            grep -E '^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$' <<< "${OPTARG}"  > /dev/null 2>&1 || { echo "Invalid scaleset name: ${OPTARG}"; exit 1; }
+            
+            if [ -z "${scalesets}" ]; then
+                scalesets="${OPTARG}"
+            else 
+                scalesets="${scalesets}:${OPTARG}"
+            fi
 
-      # echo "scalesets: ${scalesets}"
-      ;;
-    t)
-      template_repo=$OPTARG
-      ;;
-    n)
-      REPO_NAME=$OPTARG
-      ;;
-    h)
-      echo "Usage: $0 [options]"
-      echo "  -s, --scaleset <scaleset>  The scalesets to create secrets for"
-      echo "  -t, --template <template>  The template repo to use"
-      echo "  -n, --name <name>  The name for the new repository"
-      exit 0
-      ;;
-    -)
-      case "${OPTARG}" in
-        long-option)
-          long_option="${!OPTIND}"; OPTIND=$(( $OPTIND + 1 ))
-          ;;
-        *)
-          echo "Invalid option: --${OPTARG}" >&2
-          exit 1
-          ;;
-      esac;;
-    \?)
-      echo "Invalid option: -${OPTARG}" >&2
-      exit 1
-      ;;
-    :)
-      echo "Option -${OPTARG} requires an argument." >&2
-      exit 1
-      ;;
-  esac
+            # echo "scalesets: ${scalesets}"
+            ;;
+        t)
+            template_repo=$OPTARG
+            ;;
+        n)
+            REPO_NAME=$OPTARG
+            ;;
+        h)
+            echo "Usage: $0 [options]"
+            echo "  -s <scaleset>  The scalesets to create secrets for"
+            echo "  -t <template>  The template repo to use"
+            echo "  -n <name>  The name for the new repository"
+            exit 0
+            ;;
+        \?)
+            echo "Invalid option: -${OPTARG}" >&2
+            exit 1
+            ;;
+        :)
+            echo "Option -${OPTARG} requires an argument." >&2
+            exit 1
+            ;;
+    esac
 done
 
 if [ -z "${scalesets}" ]; then


### PR DESCRIPTION
Introduces the ability to specify a template repository and a custom name for the new repository via command line options in the `gh-mini-arc` script.

- Adds a new command line option `-n` to allow users to specify the name of the new repository they wish to create.
- Modifies the script to use the provided repository name if the `-n` option is used, ensuring it falls back to the default naming convention if `-n` is not provided.
- Updates the help message to include the new `-n` option with its description, enhancing user guidance on available options.
- fix: corrects the variable name from `template_rep` to `template_repo`